### PR TITLE
feat: add initial simple_syntax_colors option

### DIFF
--- a/lua/astrotheme/groups/lsp.lua
+++ b/lua/astrotheme/groups/lsp.lua
@@ -1,4 +1,4 @@
-local function callback()
+local function callback(opts)
   local error = C.ui.red
   local hint = C.ui.cyan
   local info = C.ui.blue
@@ -23,16 +23,31 @@ local function callback()
     ["@lsp.type.keyword"] = { link = "Keyword" },
     ["@lsp.type.operator"] = { link = "Operator" },
     ["@lsp.type.parameter"] = { link = "@parameter" },
-    ["@lsp.type.property"] = { link = "@property" },
+    -- ["@lsp.type.property"] = { link = "@property" },
     ["@lsp.type.variable"] = { link = "@lsp.type.variable" },
-    ["@lsp.typemod.enumMember.defaultLibrary"] = { fg = C.syntax.cyan, bg = C.none },
-    ["@lsp.typemod.function.defaultLibrary"] = { fg = C.syntax.cyan, bg = C.none },
-    ["@lsp.typemod.function.global"] = { fg = C.syntax.cyan, bg = C.none },
-    ["@lsp.typemod.method.defaultLibrary"] = { fg = C.syntax.cyan, bg = C.none },
+    ["@lsp.typemod.enumMember.defaultLibrary"] = {
+      fg = opts.simple_syntax_colors and C.syntax.blue or C.syntax.cyan,
+      bg = C.none,
+    },
+    ["@lsp.typemod.function.defaultLibrary"] = {
+      fg = opts.simple_syntax_colors and C.syntax.blue or C.syntax.cyan,
+      bg = C.none,
+    },
+    ["@lsp.typemod.function.global"] = {
+      fg = opts.simple_syntax_colors and C.syntax.blue or C.syntax.cyan,
+      bg = C.none,
+    },
+    ["@lsp.typemod.method.defaultLibrary"] = {
+      fg = opts.simple_syntax_colors and C.syntax.blue or C.syntax.cyan,
+      bg = C.none,
+    },
     ["@lsp.typemod.method.reference"] = { link = "Function" },
     ["@lsp.typemod.method.trait"] = { link = "Function" },
     ["@lsp.typemod.selfKeyword.defaultLibrary"] = { link = "Keyword" },
-    ["@lsp.typemod.variable.defaultLibrary"] = { fg = C.syntax.yellow, bg = C.none },
+    ["@lsp.typemod.variable.defaultLibrary"] = {
+      fg = opts.simple_syntax_colors and C.syntax.cyan or C.syntax.yellow,
+      bg = C.none,
+    },
     ["@lsp.typemod.variable.readonly"] = { link = "Constant" },
 
     -- rust

--- a/lua/astrotheme/groups/plugins/nvim-treesitter.lua
+++ b/lua/astrotheme/groups/plugins/nvim-treesitter.lua
@@ -1,4 +1,4 @@
-local function callback()
+local function callback(opts)
   return {
 
     -- misc
@@ -30,7 +30,7 @@ local function callback()
 
     -- function
     ["@function"] = { link = "Function" },
-    ["@function.builtin"] = { fg = C.syntax.cyan },
+    ["@function.builtin"] = { fg = opts.simple_syntax_colors and C.syntax.blue or C.syntax.cyan },
     ["@function.call"] = { link = "@function" },
     ["@function.macro"] = { fg = C.syntax.yellow },
 
@@ -38,7 +38,10 @@ local function callback()
     ["@method.call"] = { link = "@method" },
 
     ["@constructor"] = { link = "@function" },
-    ["@parameter"] = { fg = C.syntax.orange },
+    ["@parameter"] = {
+      fg = opts.simple_syntax_colors and C.syntax.text or C.syntax.orange,
+      -- underline = opts.simple_syntax_colors,
+    },
 
     -- keyword
     ["@keyword"] = { link = "Keyword" },
@@ -65,12 +68,17 @@ local function callback()
 
     ["@storageclass"] = { link = "StorageClass" },
     ["@attribute"] = { fg = C.syntax.yellow },
-    ["@field"] = { link = "@property" },
-    ["@property"] = { fg = C.syntax.red },
+    ["@field"] = {
+      fg = opts.simple_syntax_colors and C.syntax.text or C.syntax.red,
+    },
+    ["@property"] = { fg = opts.simple_syntax_colors and C.syntax.text or C.syntax.red },
 
     -- identifiers
     ["@variable"] = { link = "Identifier" },
-    ["@variable.builtin"] = { fg = C.syntax.cyan },
+    ["@variable.builtin"] = {
+      fg = opts.simple_syntax_colors and C.syntax.text or C.syntax.cyan,
+      bold = opts.simple_syntax_colors,
+    },
 
     ["@constant"] = { link = "Constant" },
     ["@constant.builtin"] = { link = "@constant" },

--- a/lua/astrotheme/groups/syntax.lua
+++ b/lua/astrotheme/groups/syntax.lua
@@ -13,7 +13,7 @@ local function callback(opts)
     -- Comment
     Comment = { fg = C.syntax.comment, bg = C.none, italic = opts.italic_comments }, -- any comment
     -- Constant
-    Constant = { fg = C.syntax.yellow, bg = C.none }, -- any constant
+    Constant = { fg = opts.simple_syntax_colors and C.syntax.cyan or C.syntax.yellow, bg = C.none }, -- any constant
     String = { fg = C.syntax.green, bg = C.none }, -- a string constant: "this is a string"
     Character = { fg = C.syntax.green, bg = C.none }, -- a character constant: 'c', '\n'
     Number = { fg = C.syntax.orange, bg = C.none }, -- a number constant: 234, 0xff
@@ -27,7 +27,7 @@ local function callback(opts)
     Conditional = { fg = C.syntax.purple, bg = C.none }, -- if, then, else, endif, switch, etc.
     Repeat = { fg = C.syntax.purple, bg = C.none }, -- for, do, while, etc.
     Label = { fg = C.syntax.blue, bg = C.none }, -- case, default, etc.
-    Operator = { fg = C.syntax.text, bg = C.none }, -- "sizeof", "+", "*", etc.
+    Operator = { fg = opts.simple_syntax_colors and C.syntax.purple or C.syntax.text, bg = C.none }, -- "sizeof", "+", "*", etc.
     Keyword = { fg = C.syntax.purple, bg = C.none }, -- any other keyword
     Exception = { fg = C.syntax.purple, bg = C.none }, -- try, catch, throw
     -- Preproc

--- a/lua/astrotheme/lib/config.lua
+++ b/lua/astrotheme/lib/config.lua
@@ -12,6 +12,7 @@ M.default = {
     popup = true,
     neotree = true,
     italic_comments = true,
+    simple_syntax_colors = false,
   },
   background = {
     light = "astrolight",


### PR DESCRIPTION
Decrease the amount of colors that are used for main parts of highlighting as some people find too many colors distracting, 