### PR TITLE
feat: handle the conversion of theme names with hyphens to underscores

### DIFF
--- a/lua/astrotheme/init.lua
+++ b/lua/astrotheme/init.lua
@@ -27,6 +27,7 @@ function M.load(theme)
     theme = M.config.background[vim.o.background]
   end
   M.config.palette = theme
+  M.config.palette = theme:gsub("-", "_")
   util.reload(M.config, theme)
 
   C = util.set_palettes(M.config)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
<!-- Add a brief description of the pr -->
This change is so theme names can be called "astromars-light" and
will be converted to "astromars_light" internally so settings can
be `astromars_light = {}` and not `["astromars-light"] = {}`.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
