### PR TITLE
feat(treesitter): modify markup highlights for better color distinction

### DIFF
--- a/lua/astrotheme/groups/treesitter.lua
+++ b/lua/astrotheme/groups/treesitter.lua
@@ -112,9 +112,9 @@ local function callback(opts)
 
     ["@markup.link"] = { fg = C.syntax.yellow, bold = true },
     ["@markup.link.label"] = { link = "String" },
-    ["@markup.link.url"] = { fg = C.syntax.green, italic = true, underline = true },
+    ["@markup.link.url"] = { fg = C.syntax.blue, italic = true, underline = true },
 
-    ["@markup.raw"] = { fg = C.syntax.text },
+    ["@markup.raw"] = { fg = C.syntax.red },
     ["@markup.raw.block"] = { fg = C.syntax.text },
 
     ["@markup.list"] = { link = "Special" },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This PR aims to improve readability when it comes to look at `.md` files, since they were no distinction between some treesitter variables.

- [x] Completed

## ℹ Additional Information

- Before the changes:
<img width="1345" alt="Astrotheme before changes (plain)" src="https://github.com/AstroNvim/astrotheme/assets/71392160/9ebef10e-8fd1-4815-956e-970e11eb3a4c">

- After the changes:
<img width="1345" alt="Astrothem after the changes (readable)" src="https://github.com/AstroNvim/astrotheme/assets/71392160/3f39b6f9-25c7-4b8d-a960-cc6884dd1ed9">

> [!NOTE]
>
> As you can see, before the changes all seemed to have the same importance/distinction.
>
> After the changes, at a glance you can distinguish between URLs and `inline raw`.