### PR TITLE
fix(plugins): improve fzf colors for light theme readability

### DIFF
--- a/lua/astrotheme/groups/plugins/fzf.lua
+++ b/lua/astrotheme/groups/plugins/fzf.lua
@@ -16,6 +16,15 @@ local function callback(c, opts)
         or c.ui.base,
       bold = true,
     },
+    FzfLuaHeaderBind = {
+      fg = c.ui.cyan,
+    },
+    FzfLuaPathLineNr = {
+      fg = c.ui.green,
+    },
+    FzfLuaHeaderText = {
+      fg = c.ui.red,
+    },
   }
 end
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
I've replaced some defaults from fzf-lua that are taken from `nvim_get_color_map` which are quite bad when using the light theme.

I don't know if these are good choices or if it should be done in some other way :slightly_smiling_face: 
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
| Before | After |
|--------|-------|
| ![1](https://github.com/user-attachments/assets/769e5626-64e4-4091-b125-0ff869447ecd) | ![2](https://github.com/user-attachments/assets/ff5e5d79-01c9-4451-a553-656d4d94e099) |
| ![3](https://github.com/user-attachments/assets/7b28f0ba-a0bf-4786-99f6-ff81c0bbdfdd) | ![4](https://github.com/user-attachments/assets/f990f31f-959e-4c5d-8601-6bf36ad901a7) |

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
