### PR TITLE
feat(extras): add Konsole

### DIFF
--- a/lua/astrotheme/extras/init.lua
+++ b/lua/astrotheme/extras/init.lua
@@ -24,6 +24,7 @@ M.extras = {
   helix            = { ext = "toml", url = "https://helix-editor.com/", label = "Helix" },
   iterm            = { ext = "itermcolors", url = "https://iterm2.com/", label = "iTerm" },
   kitty            = { ext = "conf", url = "https://sw.kovidgoyal.net/kitty/conf.html", label = "Kitty" },
+  konsole          = { ext = "colorscheme", url = "https://konsole.kde.org/", label = "Konsole" },
   lazygit          = { ext = "yml", url = "https://github.com/jesseduffield/lazygit", label = "Lazygit" },
   lua              = { ext = "lua", url = "https://www.lua.org", label = "Lua Table for testing" },
   monkeytype       = { ext = "md", url = "https://monkeytype.com", label = "MonkeyType" },

--- a/lua/astrotheme/extras/konsole.lua
+++ b/lua/astrotheme/extras/konsole.lua
@@ -1,0 +1,126 @@
+local util = require "astrotheme.extras"
+
+local M = {}
+
+local function normalize_colors(colors)
+  local new_colors = {}
+  for key, value in pairs(colors) do
+    local new_value = value
+    if type(value) == "string" and value:match "^#" then
+      local hex = value:gsub("^#", "")
+      new_value =
+        string.format("%d,%d,%d", tonumber(hex:sub(1, 2), 16), tonumber(hex:sub(3, 4), 16), tonumber(hex:sub(5, 6), 16))
+    elseif type(value) == "table" then
+      new_value = normalize_colors(value)
+    end
+    new_colors[key] = new_value
+  end
+  return new_colors
+end
+
+--- @param colors AstroThemePalette
+function M.generate(colors)
+  return util.template(
+    [[
+[Background]
+Color=${ui.base}
+
+[BackgroundFaint]
+Color=${ui.base}
+
+[BackgroundIntense]
+Color=${ui.base}
+
+[Color0]
+Color=${term.black}
+
+[Color0Faint]
+Color=${term.black}
+
+[Color0Intense]
+Color=${term.bright_black}
+
+[Color1]
+Color=${term.red}
+
+[Color1Faint]
+Color=${term.red}
+
+[Color1Intense]
+Color=${term.bright_red}
+
+[Color2]
+Color=${term.green}
+
+[Color2Faint]
+Color=${term.green}
+
+[Color2Intense]
+Color=${term.bright_green}
+
+[Color3]
+Color=${term.yellow}
+
+[Color3Faint]
+Color=${term.yellow}
+
+[Color3Intense]
+Color=${term.bright_yellow}
+
+[Color4]
+Color=${term.blue}
+
+[Color4Faint]
+Color=${term.blue}
+
+[Color4Intense]
+Color=${term.bright_blue}
+
+[Color5]
+Color=${term.purple}
+
+[Color5Faint]
+Color=${term.purple}
+
+[Color5Intense]
+Color=${term.bright_purple}
+
+[Color6]
+Color=${term.cyan}
+
+[Color6Faint]
+Color=${term.cyan}
+
+[Color6Intense]
+Color=${term.bright_cyan}
+
+[Color7]
+Color=${term.white}
+
+[Color7Faint]
+Color=${term.white}
+
+[Color7Intense]
+Color=${term.bright_white}
+
+[Foreground]
+Color=${syntax.text}
+
+[ForegroundFaint]
+Color=${term.white}
+
+[ForegroundIntense]
+Color=${term.bright_white}
+
+[General]
+Blur=false
+ColorRandomization=false
+Description=${_style_name}
+Opacity=1
+Wallpaper=
+]],
+    normalize_colors(colors)
+  )
+end
+
+return M


### PR DESCRIPTION
## 📑 Description

Add a Konsole extras generator for AstroTheme palettes:

- [x] Add `lua/astrotheme/extras/konsole.lua`
- [x] Register the Konsole extra in `lua/astrotheme/extras/init.lua`
- [x] Verify `extras/konsole/astrodark.colorscheme` is generated with `make extras`
